### PR TITLE
Implement caching for Bitwarden CLI state to prevent "new device" emails

### DIFF
--- a/.github/workflows/cli-compat-test.yml
+++ b/.github/workflows/cli-compat-test.yml
@@ -11,11 +11,23 @@ on:
   pull_request:
     branches:
       - main
+  # Push to main only: validates main and seeds the device-id cache that PRs
+  # restore (PRs can read caches from main, not from each other). Feature-branch
+  # pushes are already covered by their PR, so running on every branch is waste.
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
+
+# Serialize repo-wide: a heavy run clears + re-imports the shared throwaway cloud
+# destination, so two overlapping runs would corrupt each other's vault. Queue
+# rather than cancel — cancelling mid-sync could leave the dest half-cleared.
+concurrency:
+  group: cli-compat
+  cancel-in-progress: false
 
 jobs:
   cli-compat:
@@ -23,6 +35,7 @@ jobs:
     # protection. Keep it in sync with that setting.
     name: CLI Compatibility Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -30,20 +43,36 @@ jobs:
 
       - name: Detect CLI-relevant changes
         id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only \
-              "${{ github.event.pull_request.base.sha }}" \
-              "${{ github.event.pull_request.head.sha }}" \
+          case "$EVENT" in
+            pull_request) base="$PR_BASE"; head="$PR_HEAD" ;;
+            push)         base="$PUSH_BEFORE"; head="$PUSH_AFTER" ;;
+            *)            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0 ;;  # manual dispatch
+          esac
+          # New branch / unknown base (all-zero SHA) → can't diff, run to be safe.
+          case "$base" in "" | 0000000000000000000000000000000000000000)
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0 ;;
+          esac
+          if git diff --name-only "$base" "$head" \
               | grep -qE '^(docker/|test/cli-compat/|\.github/workflows/cli-compat-test\.yml$)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "relevant=false" >> "$GITHUB_OUTPUT"
             echo "No CLI/Vaultwarden-relevant changes — reporting success without running the sync."
           fi
+
+      - name: Cache Bitwarden CLI state (stable device id → no "new device" emails)
+        if: steps.filter.outputs.relevant == 'true'
+        uses: actions/cache@v4
+        with:
+          path: test/cli-compat/.bw-appdata
+          key: cli-compat-bw-appdata
 
       - name: Run CLI compatibility test
         if: steps.filter.outputs.relevant == 'true'

--- a/test/cli-compat/.gitignore
+++ b/test/cli-compat/.gitignore
@@ -1,0 +1,2 @@
+# Persisted Bitwarden CLI state created at test time (cached by CI, not committed).
+.bw-appdata/

--- a/test/cli-compat/run.sh
+++ b/test/cli-compat/run.sh
@@ -104,6 +104,8 @@ docker run --rm --network host \
   -e BW_SERVER_DEST -e BW_CLIENTID_DEST -e BW_CLIENTSECRET_DEST -e BW_PASS_DEST \
   -e BW_TAR_PASS="cli-compat-test" \
   -e BITWARDENCLI_APPDATA_DIR="/tmp/bw" \
+  -e BW_DEVICE_IDENTIFIER="${BW_DEVICE_IDENTIFIER:-7b9e6f1c-2a3d-4e5f-8a9b-0c1d2e3f4a5b}" \
+  -e BW_DEVICE_NAME="${BW_DEVICE_NAME:-bitwarden-sync-ci}" \
   -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
   -e NODE_OPTIONS="--no-deprecation --no-warnings" \
   "$IMAGE_TAG" /app/script.sh 2>&1 | tee "$LOG"

--- a/test/cli-compat/run.sh
+++ b/test/cli-compat/run.sh
@@ -26,6 +26,13 @@ COMPOSE="$HERE/docker-compose.yml"
 IMAGE_TAG="${IMAGE_TAG:-bitwarden-sync:cli-compat}"
 PORT="${PORT:-8000}"
 
+# Persisted Bitwarden CLI state (the bw-new CLI's own device id lives here). The
+# workflow caches this dir so the cloud dest sees the same device every run and
+# stops emailing "new device logged in". Paired with the fixed BW_DEVICE_IDENTIFIER
+# below, which covers the separate REST API-key login.
+APPDATA="${BW_CLI_APPDATA:-$HERE/.bw-appdata}"
+mkdir -p "$APPDATA"
+
 fail() { echo "::error::$*" >&2; exit 1; }
 
 # Source = the in-CI Vaultwarden (seeded volume); dest = real Bitwarden Cloud.
@@ -102,8 +109,9 @@ docker run --rm --network host \
   -e BW_SERVER_SOURCE="https://localhost:$PORT" \
   -e BW_CLIENTID_SOURCE -e BW_CLIENTSECRET_SOURCE -e BW_PASS_SOURCE \
   -e BW_SERVER_DEST -e BW_CLIENTID_DEST -e BW_CLIENTSECRET_DEST -e BW_PASS_DEST \
+  -v "$APPDATA":/bw-appdata \
   -e BW_TAR_PASS="cli-compat-test" \
-  -e BITWARDENCLI_APPDATA_DIR="/tmp/bw" \
+  -e BITWARDENCLI_APPDATA_DIR=/bw-appdata \
   -e BW_DEVICE_IDENTIFIER="${BW_DEVICE_IDENTIFIER:-7b9e6f1c-2a3d-4e5f-8a9b-0c1d2e3f4a5b}" \
   -e BW_DEVICE_NAME="${BW_DEVICE_NAME:-bitwarden-sync-ci}" \
   -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
@@ -111,6 +119,11 @@ docker run --rm --network host \
   "$IMAGE_TAG" /app/script.sh 2>&1 | tee "$LOG"
 rc=${PIPESTATUS[0]}
 set -e
+
+# The CLI state was written as root; chown it back so the workflow cache can save
+# it (and so local re-runs aren't blocked by root-owned files).
+docker run --rm --entrypoint chown -v "$APPDATA":/bw-appdata "$IMAGE_TAG" \
+  -R "$(id -u):$(id -g)" /bw-appdata >/dev/null 2>&1 || true
 
 # 4. Assert.
 [ "$rc" -eq 0 ] || fail "sync exited with code $rc"


### PR DESCRIPTION
Introduce caching for the Bitwarden CLI state to eliminate unnecessary "new device" emails. Add environment variables for device identifier and name to enhance CLI compatibility testing.