### PR TITLE
ci: scope CLI Compatibility Test concurrency per-PR (fix stranded checks)

### DIFF
--- a/.github/workflows/cli-compat-test.yml
+++ b/.github/workflows/cli-compat-test.yml
@@ -26,7 +26,14 @@ permissions:
 # destination, so two overlapping runs would corrupt each other's vault. Queue
 # rather than cancel — cancelling mid-sync could leave the dest half-cleared.
 concurrency:
-  group: cli-compat
+  # Per-PR (and per-branch) rather than one global group. A single global group
+  # would cancel a still-pending run whenever several PRs/pushes landed close
+  # together — and a cancelled run on a PR's HEAD leaves its required
+  # "CLI Compatibility Test" check missing, blocking the PR forever (this is
+  # exactly what stranded #71). Scoping the group per PR keeps runs from
+  # cancelling each other. Heavy CLI-relevant syncs are rare, so the loss of
+  # cross-PR serialization is an acceptable trade for never stranding a check.
+  group: cli-compat-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
**Problem:** the global `concurrency: cli-compat` group cancels a pending run when multiple PRs/pushes land together. A cancelled run on a PR's HEAD leaves the required `CLI Compatibility Test` check **missing**, blocking the PR forever — exactly what happened to #71 (its last check run was `cancelled` at 2026-07-02 11:29). #72's survived, so it merged fine.

**Fix:** scope the concurrency group per-PR/branch so runs can't cancel each other. Heavy CLI-relevant syncs are rare, so losing cross-PR serialization is a fair trade for never stranding the required check.

(This PR edits `cli-compat-test.yml`, so it correctly runs the full E2E compatibility test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)