### PR TITLE
ci: self-host Renovate and align config with gold-standard automation

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ name: Renovate
 #      branches).
 on:
   schedule:
-    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
   workflow_dispatch:
     inputs:
       logLevel:
@@ -48,6 +48,6 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github
-          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: required
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,53 @@
+name: Renovate
+
+# Self-hosted Renovate — no third-party GitHub App. Runs on a schedule (and on
+# demand), opens dependency PRs, and auto-merges the safe ones once the
+# required "CLI Compatibility Test" check passes. Renovate also updates the
+# renovatebot/github-action pin below, so it keeps itself current too.
+#
+# Setup (one-time):
+#   1. Create a fine-grained PAT (this repo only) with Read+Write on:
+#      Contents, Pull requests, Workflows — and save it as the RENOVATE_TOKEN
+#      repo secret. (PRs opened with the default GITHUB_TOKEN would not
+#      trigger CI, so required checks would never pass and nothing would
+#      auto-merge.)
+#   2. Repo Settings → General → allow auto-merge.
+#   3. Branch protection / ruleset on main → require status check:
+#      "CLI Compatibility Test".
+#   4. Uninstall/disable the hosted Mend/Renovate GitHub App on this repo so
+#      it doesn't run alongside this self-hosted job (both would otherwise
+#      manage the same Dependency Dashboard issue and could open duplicate
+#      branches).
+on:
+  schedule:
+    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level
+        default: info
+        type: choice
+        options: [info, debug]
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.18
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_PLATFORM: github
+          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_REQUIRE_CONFIG: required
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
+  "extends": ["config:recommended", ":semanticCommits", ":dependencyDashboard"],
   "description": [
-    "platformAutomerge uses GitHub-native auto-merge, which is gated by branch protection: 'Allow auto-merge' is enabled and main requires the 'CLI Compatibility Test' check, so a bump only merges once that check is green. The check runs on every PR (skipping the heavy sync when irrelevant) so it never blocks unrelated PRs."
+    "platformAutomerge uses GitHub-native auto-merge, which is gated by branch protection: 'Allow auto-merge' is enabled and main requires the 'CLI Compatibility Test' check, so a bump only merges once that check is green. The check runs on every PR (skipping the heavy sync when irrelevant) so it never blocks unrelated PRs. All update types (major/minor/patch/pin/digest) auto-merge — CI is the gate, not semver.",
+    "Self-hosted via .github/workflows/renovate.yml (weekly cron + manual dispatch); cadence lives there, not here."
   ],
   "automerge": true,
   "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",


### PR DESCRIPTION
## Automation audit (daily babysit-prs run)

This repo's CI/release automation already closely matches the gold standard (`martadams89/seo-website-indexer`):
- `.github/workflows/cli-compat-test.yml` is a real, appropriately-scoped test suite for this repo's actual stack (bash script + Docker), running on both `push` and `pull_request` to `main`, and is the required merge-gate check ("CLI Compatibility Test").
- `.github/workflows/release.yml` already covers automated releases (release-please) plus multi-arch image publish.

The one gap: Renovate was running via the **hosted Mend/Renovate GitHub App** (see issue #5, the Dependency Dashboard, authored by `mend.io`), not self-hosted via Actions + `RENOVATE_TOKEN` like the gold standard.

### Changes
- Add `.github/workflows/renovate.yml`: self-hosted Renovate, weekly cron (`0 3 * * 1`) + `workflow_dispatch`, authenticated with the `RENOVATE_TOKEN` secret — mirrors `seo-website-indexer`'s workflow, adapted to this repo's required check name (`CLI Compatibility Test`).
- Update `renovate.json`: add `:semanticCommits` to `extends` and a `lockFileMaintenance` block to match the standard shape. The existing top-level `automerge: true` + `platformAutomerge: true` already applied to all update types (major/minor/patch/pin/digest) with no update-type restriction, so auto-merge behavior for dependency PRs is unchanged — only the execution mechanism changes.

### Manual follow-up required (no tool access to these from this session)
1. `gh secret set RENOVATE_TOKEN --repo martadams89/bitwarden-sync --body "<RENOVATE_PAT>"` — fine-grained PAT scoped to this repo only, with Read+Write on Contents, Pull requests, Workflows.
2. `gh api -X PATCH repos/martadams89/bitwarden-sync -f allow_auto_merge=true`
3. Branch protection on `main`: require the **"CLI Compatibility Test"** status check (no required reviews needed — CI is the gate).
4. Uninstall/disable the hosted Mend/Renovate GitHub App on this repo once the above is confirmed working, so it doesn't run alongside this self-hosted job and open duplicate branches / fight over the Dependency Dashboard issue.

No open PRs and no held-update `packageRule`s (`"enabled": false"` on `docker/docker-compose.yml` is a permanent template exclusion, not a compatibility hold) were found during this audit.

Co-Authored-By: Claude <claude-sonnet-5@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_017anq3d4L4uQEZugiFoHgZY)_