### PR TITLE
chore(renovate): run daily at 2am UTC

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ name: Renovate
 #      branches).
 on:
   schedule:
-    - cron: '0 2 * * *' # daily at 2am UTC
+    - cron: "0 2 * * *" # daily at 2am UTC
   workflow_dispatch:
     inputs:
       logLevel:
@@ -48,6 +48,6 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_PLATFORM: github
-          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_ONBOARDING: "false"
           RENOVATE_REQUIRE_CONFIG: required
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ name: Renovate
 #      branches).
 on:
   schedule:
-    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+    - cron: '0 2 * * *' # daily at 2am UTC
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,53 @@
+name: Renovate
+
+# Self-hosted Renovate — no third-party GitHub App. Runs on a schedule (and on
+# demand), opens dependency PRs, and auto-merges the safe ones once the
+# required "CLI Compatibility Test" check passes. Renovate also updates the
+# renovatebot/github-action pin below, so it keeps itself current too.
+#
+# Setup (one-time):
+#   1. Create a fine-grained PAT (this repo only) with Read+Write on:
+#      Contents, Pull requests, Workflows — and save it as the RENOVATE_TOKEN
+#      repo secret. (PRs opened with the default GITHUB_TOKEN would not
+#      trigger CI, so required checks would never pass and nothing would
+#      auto-merge.)
+#   2. Repo Settings → General → allow auto-merge.
+#   3. Branch protection / ruleset on main → require status check:
+#      "CLI Compatibility Test".
+#   4. Uninstall/disable the hosted Mend/Renovate GitHub App on this repo so
+#      it doesn't run alongside this self-hosted job (both would otherwise
+#      manage the same Dependency Dashboard issue and could open duplicate
+#      branches).
+on:
+  schedule:
+    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level
+        default: info
+        type: choice
+        options: [info, debug]
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.18
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_PLATFORM: github
+          RENOVATE_ONBOARDING: 'false'
+          RENOVATE_REQUIRE_CONFIG: required
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
+  "extends": ["config:recommended", ":semanticCommits", ":dependencyDashboard"],
   "description": [
-    "platformAutomerge uses GitHub-native auto-merge, which is gated by branch protection: 'Allow auto-merge' is enabled and main requires the 'CLI Compatibility Test' check, so a bump only merges once that check is green. The check runs on every PR (skipping the heavy sync when irrelevant) so it never blocks unrelated PRs."
+    "platformAutomerge uses GitHub-native auto-merge, which is gated by branch protection: 'Allow auto-merge' is enabled and main requires the 'CLI Compatibility Test' check, so a bump only merges once that check is green. The check runs on every PR (skipping the heavy sync when irrelevant) so it never blocks unrelated PRs. All update types (major/minor/patch/pin/digest) auto-merge — CI is the gate, not semver.",
+    "Self-hosted via .github/workflows/renovate.yml (weekly cron + manual dispatch); cadence lives there, not here."
   ],
   "automerge": true,
   "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",


### PR DESCRIPTION
Standardizes the Renovate workflow schedule to a single daily run at 02:00 UTC (was weekly, Mondays 03:00 UTC), per fleet-wide scheduling change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017anq3d4L4uQEZugiFoHgZY)_