### PR TITLE
chore(renovate): run daily at 2am UTC

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ name: Renovate
 #      branches).
 on:
   schedule:
-    - cron: "0 3 * * 1" # Mondays 03:00 UTC
+    - cron: "0 2 * * *" # daily at 2am UTC
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
Standardizes the Renovate workflow schedule to a single daily run at 02:00 UTC (was weekly, Mondays 03:00 UTC), per fleet-wide scheduling change. Replaces #84, which conflicted with Renovate's own action-version-bump commits merged in the meantime.

---
_Generated by [Claude Code](https://claude.ai/code/session_017anq3d4L4uQEZugiFoHgZY)_