### PR TITLE
fix: prevent backup cleanup from deleting app scripts

### DIFF
--- a/.github/workflows/cli-compat-test.yml
+++ b/.github/workflows/cli-compat-test.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test backup cleanup safety
+        run: bash test/backup-cleanup/run.sh
+
       - name: Detect CLI-relevant changes
         id: filter
         env:

--- a/docker/bitwarden_sync.sh
+++ b/docker/bitwarden_sync.sh
@@ -405,10 +405,7 @@ SOURCE_OUTPUT_FILE_JSON=/app/backups/$SOURCE_EXPORT_OUTPUT_BASE$TIMESTAMP.json
 
 # Delete previous backups over 30 days old
 echo "# Deleting previous backups older than 30 days... #"
-current_date=$(date +%Y-%m-%d)
-source_export_files=$(find /app/backups -type f -name "bw_export_*.tar.gz.enc")
-find $source_export_files -type f -mtime +30 -exec rm -f {} +
-rm -f -R $SOURCE_EXPORT_OUTPUT_BASE*.json
+cleanup_backup_files /app/backups
 
 # Login to our Server (using old CLI for Vaultwarden compatibility) and unlock.
 # source_login_unlock handles logout/config/login/unlock with retry + backoff.

--- a/docker/bw-cli-lib.sh
+++ b/docker/bw-cli-lib.sh
@@ -2,6 +2,21 @@
 # Sourced by docker/entrypoint.sh (boot-time version reconcile) and
 # docker/bitwarden_sync.sh (run-time auto-fallback). Not executable on its own.
 
+# Remove stale backup artifacts without ever allowing an empty file list to
+# become an unscoped `find` from the caller's working directory. Run in a
+# subshell so the temporary variable cannot leak into the calling script.
+#   $1 = backup directory
+cleanup_backup_files() (
+  backup_dir="$1"
+
+  [ -d "$backup_dir" ] || return 0
+
+  find "$backup_dir" -type f -name "bw_export_*.tar.gz.enc" \
+    -mtime +30 -exec rm -f -- {} +
+  find "$backup_dir" -type f -name "bw_export_*.json" \
+    -exec rm -f -- {} +
+)
+
 # Reinstall the isolated "old" CLI (used for the Vaultwarden source) at the
 # given version, then restore the global "new" CLI (used for the cloud
 # destination). Builds into a temp dir and swaps, so a failure mid-install can't

--- a/test/backup-cleanup/run.sh
+++ b/test/backup-cleanup/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression test for issue #103: an empty backup directory must never make the
+# cleanup search fall back to /app (or to any other working directory).
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/../.." && pwd)
+
+# shellcheck source=../../docker/bw-cli-lib.sh
+. "$ROOT/docker/bw-cli-lib.sh"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+APP_DIR="$TEST_ROOT/app"
+BACKUP_DIR="$APP_DIR/backups"
+mkdir -p "$BACKUP_DIR"
+
+# These model the image's baked-in scripts. Make them old enough that the
+# original unscoped find command would delete them.
+touch "$APP_DIR/entrypoint.sh" "$APP_DIR/script.sh" "$APP_DIR/bw-cli-lib.sh"
+touch -d "45 days ago" \
+  "$APP_DIR/entrypoint.sh" "$APP_DIR/script.sh" "$APP_DIR/bw-cli-lib.sh"
+
+(
+  cd "$APP_DIR"
+  cleanup_backup_files "$BACKUP_DIR"
+)
+
+for script in entrypoint.sh script.sh bw-cli-lib.sh; do
+  [ -f "$APP_DIR/$script" ] || fail "empty backup cleanup deleted $script"
+done
+
+# Confirm the cleanup remains selective: only expired encrypted archives and
+# stale plaintext exports are removed.
+touch "$BACKUP_DIR/bw_export_old.tar.gz.enc"
+touch -d "45 days ago" "$BACKUP_DIR/bw_export_old.tar.gz.enc"
+touch "$BACKUP_DIR/bw_export_recent.tar.gz.enc"
+touch "$BACKUP_DIR/bw_export_interrupted.json"
+touch "$BACKUP_DIR/unrelated-old-file.txt"
+touch -d "45 days ago" "$BACKUP_DIR/unrelated-old-file.txt"
+
+cleanup_backup_files "$BACKUP_DIR"
+
+[ ! -e "$BACKUP_DIR/bw_export_old.tar.gz.enc" ] || fail "expired archive was retained"
+[ ! -e "$BACKUP_DIR/bw_export_interrupted.json" ] || fail "stale JSON export was retained"
+[ -e "$BACKUP_DIR/bw_export_recent.tar.gz.enc" ] || fail "recent archive was deleted"
+[ -e "$BACKUP_DIR/unrelated-old-file.txt" ] || fail "unrelated backup file was deleted"
+
+echo "Backup cleanup regression test PASSED"


### PR DESCRIPTION
## Summary

- scope backup retention cleanup directly to `/app/backups`
- remove interrupted plaintext exports without relying on an unquoted relative glob
- add a regression test covering an empty backup directory and selective retention
- run the regression test as part of the required CLI Compatibility Test workflow

## Validation

- `bash test/backup-cleanup/run.sh`
- `bash -n docker/bitwarden_sync.sh test/backup-cleanup/run.sh`
- `sh -n docker/bw-cli-lib.sh docker/entrypoint.sh`
- `git diff --check`

Fixes #103.