### PR TITLE
fix: publish release images for root component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
       HAS_RP_TOKEN: ${{ secrets.RENOVATE_TOKEN != '' }}
     outputs:
       # Manifest mode prefixes per-package outputs with the path ("." here).
-      release_created: ${{ steps.rp.outputs['.--release_created'] }}
-      major: ${{ steps.rp.outputs['.--major'] }}
-      minor: ${{ steps.rp.outputs['.--minor'] }}
-      patch: ${{ steps.rp.outputs['.--patch'] }}
+      release_created: ${{ steps.rp.outputs.release_created }}
+      major: ${{ steps.rp.outputs.major }}
+      minor: ${{ steps.rp.outputs.minor }}
+      patch: ${{ steps.rp.outputs.patch }}
     steps:
       - id: rp
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5


### PR DESCRIPTION
## Summary

- use Release Please's documented unprefixed outputs for the root (`.`) component
- allow the Docker publish job to run after a release is created

The incorrect `.--release_created`, `.--major`, `.--minor`, and `.--patch` keys caused the v1.1.1 GitHub release to be created while silently skipping image publication.

## Validation

- confirmed v1.1.1 release logs report a created root release while the publish job was skipped
- verified output names against the official Release Please Action root-component documentation