### PR TITLE
ci: make release auto-merge repository explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ steps.rp.outputs.pr && env.HAS_RP_TOKEN == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
-        run: gh pr merge --auto --squash "${{ fromJson(steps.rp.outputs.pr).number }}"
+        run: gh pr merge --repo "$GITHUB_REPOSITORY" --auto --squash "${{ fromJson(steps.rp.outputs.pr).number }}"
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Summary

- pass the repository explicitly to `gh pr merge`
- allow Release Please's auto-merge step to work without a checkout

The v1.1.2 release workflow exposed `fatal: not a git repository` because the job intentionally has no checkout before calling `gh`.